### PR TITLE
feat: adding cloud field to identity engine

### DIFF
--- a/docs/resources/engine.md
+++ b/docs/resources/engine.md
@@ -25,6 +25,7 @@ description: |-
 
 ### Optional
 
+- `cloud` (String) Cloud that uses this engine
 - `source` (String)
 
 ### Read-Only

--- a/internal/kmi/identityclient.go
+++ b/internal/kmi/identityclient.go
@@ -29,7 +29,7 @@ func (client *KMIRestClient) SaveIdentityEngine(account string, engineName strin
 	return nil
 }
 
-func SetCloudTypeIdentityEngine(cloud string) string {
+func SetCloudType(cloud string) string {
 	if cloud != "" {
 		return cloud
 	}

--- a/internal/kmi/identityclient.go
+++ b/internal/kmi/identityclient.go
@@ -29,6 +29,13 @@ func (client *KMIRestClient) SaveIdentityEngine(account string, engineName strin
 	return nil
 }
 
+func SetCloudTypeIdentityEngine(cloud string) string {
+	if cloud != "" {
+		return cloud
+	}
+	return "linode"
+}
+
 func (client *KMIRestClient) GetIdentityEngine(account string, engineName string) (*IdentityEngine, error) {
 
 	idenityengineurl := fmt.Sprintf("%s/engine/Acct=%s/Eng=%s", client.Host, account, engineName)

--- a/internal/provider/engine_resource.go
+++ b/internal/provider/engine_resource.go
@@ -48,6 +48,10 @@ func (r *engineResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Required:    true,
 				Description: "The name of the account has been created on KMI ",
 			},
+			"cloud": schema.StringAttribute{
+				Optional:    true,
+				Description: "Cloud that uses this engine",
+			},
 			"api_endpoint": schema.StringAttribute{
 				Required:    true,
 				Description: "The Kuberenetes API endpoint of the Kuberenetes cluster has been created on KMI ",
@@ -120,7 +124,7 @@ func (r *engineResource) Create(ctx context.Context, req resource.CreateRequest,
 		workloads = append(workloads, wkload)
 	}
 	engine := kmi.KMIEngine{
-		Cloud:     "linode",
+		Cloud:     kmi.SetCloudTypeIdentityEngine(plan.Cloud.ValueString()),
 		Type:      "kubernetes",
 		Option:    options,
 		Workloads: workloads,
@@ -243,7 +247,7 @@ func (r *engineResource) Update(ctx context.Context, req resource.UpdateRequest,
 		workloads = append(workloads, wkload)
 	}
 	engine := kmi.KMIEngine{
-		Cloud:     "linode",
+		Cloud:     kmi.SetCloudTypeIdentityEngine(plan.Cloud.ValueString()),
 		Type:      "kubernetes",
 		Option:    options,
 		Workloads: workloads,
@@ -377,6 +381,7 @@ func (r *engineResource) Configure(_ context.Context, req resource.ConfigureRequ
 type EngineResourceModel struct {
 	Engine                   types.String            `tfsdk:"engine"`
 	AccountName              types.String            `tfsdk:"account_name"`
+	Cloud                    types.String            `tfsdk:"cloud"`
 	ApiEndpoint              types.String            `tfsdk:"api_endpoint"`
 	CertificateDataAuthority types.String            `tfsdk:"cas_base64"`
 	Source                   types.String            `tfsdk:"source"`

--- a/internal/provider/engine_resource.go
+++ b/internal/provider/engine_resource.go
@@ -124,7 +124,7 @@ func (r *engineResource) Create(ctx context.Context, req resource.CreateRequest,
 		workloads = append(workloads, wkload)
 	}
 	engine := kmi.KMIEngine{
-		Cloud:     kmi.SetCloudTypeIdentityEngine(plan.Cloud.ValueString()),
+		Cloud:     kmi.SetCloudType(plan.Cloud.ValueString()),
 		Type:      "kubernetes",
 		Option:    options,
 		Workloads: workloads,
@@ -247,7 +247,7 @@ func (r *engineResource) Update(ctx context.Context, req resource.UpdateRequest,
 		workloads = append(workloads, wkload)
 	}
 	engine := kmi.KMIEngine{
-		Cloud:     kmi.SetCloudTypeIdentityEngine(plan.Cloud.ValueString()),
+		Cloud:     kmi.SetCloudType(plan.Cloud.ValueString()),
 		Type:      "kubernetes",
 		Option:    options,
 		Workloads: workloads,


### PR DESCRIPTION
Feature: setting cloud field in the identity engine.
Looks like this:
```
resource "kmi_engine" "this" {                                             
  ...                                              
  cloud = "value"
  ...
} 
```